### PR TITLE
Set rejectUnauthorized to false to allow self-signed certificates

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ function get(url) {
   }
   
   return new Promise(function (resolve, reject) {
-    var req = https.get({hostname: url, agent: false}, function (res) {
+    var req = https.get({hostname: url, agent: false, rejectUnauthorized: false}, function (res) {
       var certificate = res.socket.getPeerCertificate();
       if(isEmpty(certificate) || certificate === null) {
         reject({message: 'The website did not provide a certificate'});


### PR DESCRIPTION
The node http module will error on self-signed, expired, or otherwise rejected certs. Setting rejectUnauthorized will allow this module the ability to still get those certs. 

```javascript
var sslCertficate = require('get-ssl-certificate');
sslCertficate.get('self-signed.badssl.com').then(function (certificate) {
  console.log(certificate);
});
```
