### PR TITLE
Added timeout option

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,13 +25,16 @@ function pemEncode(str, n) {
   return returnString
 }
 
-function get(url) {
+function get(url, opts) {
+  opts = opts || {};
+	
   if (url.length <= 0 || typeof url !== 'string') {
     throw Error('A valid URL is required')
   }
 
   var options = {
     hostname: url,
+	timeout: opts.timeout,
     agent: false,
     rejectUnauthorized: false,
     ciphers: 'ALL'
@@ -49,12 +52,19 @@ function get(url) {
         resolve(certificate)
       }
     })
-
+	
+	// Set timeout if required
+	if (options.timeout) {
+		req.setTimeout(options.timeout, function() {
+			reject('Timeout triggered after ' + options.timeout + ' ms');
+			req.abort();
+		})
+	}
     req.on('error', function(e) {
-      reject(e)
+      reject(e);
     })
 
-    req.end()
+    req.end();
   })
 }
 

--- a/test/index.js
+++ b/test/index.js
@@ -5,9 +5,10 @@ var should = require('chai').should(),
   https = require('https'),
   getSSLCertificate = require('../index')
 
-describe('getSSLCertificate.get()', function() {
+describe('getSSLCertificate.get() mock tests', function() {
   var mockUrl = 'https://nodejs.org'
-
+ 
+  
   var mockBase64EncodedRawBuffer =
     'MIIGSzCCBTOgAwIBAgIQZlk9V/IMvFc+QzOBtf7CgDANBgkqhkiG9w0BAQsFADCBkDELMAkGA1UEBhMCR0IxGzAZBgNVBAgTEkdyZWF0ZXIgTWFuY2hlc3RlcjEQMA4GA1UEBxMHU2FsZm9yZDEaMBgGA1UEChMRQ09NT0RPIENBIExpbWl0ZWQxNjA0BgNVBAMTLUNPTU9ETyBSU0EgRG9tYWluIFZhbGlkYXRpb24gU2VjdXJlIFNlcnZlciBDQTAeFw0xNzA4MTQwMDAwMDBaFw0xOTExMjAyMzU5NTlaMFkxITAfBgNVBAsTGERvbWFpbiBDb250cm9sIFZhbGlkYXRlZDEdMBsGA1UECxMUUG9zaXRpdmVTU0wgV2lsZGNhcmQxFTATBgNVBAMMDCoubm9kZWpzLm9yZzCCAiIwDQYJKoZIhvcNAQEBBQADggIPADCCAgoCggIBALVs5Fy3QLCaE/ZKxUO3Ev+e6OTChLVCoXCKJ+gqjRUcoXgVPhLm3aFb9w/9lsuKiGGGQb38ygNSfmZbcNd5yKNJpviP1O9lVxgL1MmBkocrz+OvVuhjwJ3di8HsWN+dlPkU8DaRArKHC+z6E0igg4ycSb0cIBJLRCR3VyNHBHUGsfzWWKgNDES8wWvFxUls/m5KhCjvZUzT2Jcr9uW/rVnJMAaDC16xBWu7OLU9FGT6bgK/3y/2bNlJSG8HdexDA07CYCrvvxcDrSIdqiqINTw7amiO/oOHgR9kXO7Xs/5G4fi59Z+tAo80m5vBQhHVgwmU0FXuo9VHkR4HoK3euKgrkYjlhyDZXNR47smvHxe+gUG+gJBvGjOURafrWyhfaAObDylFmKfRwABfwitScbB1L1jM3vjI/YVvt64hyAuKLOmDrpQEblPt5MuJ9CUC0xtTYHccAcgBVZGGN0kFUOP1VeLudcyMY23eNjPP7dYukb8PdognNpTu66IML8nxSipDVRe8HXNzkiRjQJq2Aylc6wu1N4ejNMnKPKizAAXFpi/AcVCDRi4AcZqPo+0KmCjDhxNgpz+LBKT8HnEwKETpu5lAt350XJ2R8ibXGvytSxE6r2jZKyTdtKITa1WhzRrfOWBbY8tjkDjtD0yYdomGZ0Omh2nMVYR+SgbW4uPxAgMBAAGjggHVMIIB0TAfBgNVHSMEGDAWgBSQr2o6lFoL2JDqElZz30O0Oija5zAdBgNVHQ4EFgQUcMdzKdAgAd58S29IuEIabcmg6jcwDgYDVR0PAQH/BAQDAgWgMAwGA1UdEwEB/wQCMAAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsGAQUFBwMCME8GA1UdIARIMEYwOgYLKwYBBAGyMQECAgcwKzApBggrBgEFBQcCARYdaHR0cHM6Ly9zZWN1cmUuY29tb2RvLmNvbS9DUFMwCAYGZ4EMAQIBMFQGA1UdHwRNMEswSaBHoEWGQ2h0dHA6Ly9jcmwuY29tb2RvY2EuY29tL0NPTU9ET1JTQURvbWFpblZhbGlkYXRpb25TZWN1cmVTZXJ2ZXJDQS5jcmwwgYUGCCsGAQUFBwEBBHkwdzBPBggrBgEFBQcwAoZDaHR0cDovL2NydC5jb21vZG9jYS5jb20vQ09NT0RPUlNBRG9tYWluVmFsaWRhdGlvblNlY3VyZVNlcnZlckNBLmNydDAkBggrBgEFBQcwAYYYaHR0cDovL29jc3AuY29tb2RvY2EuY29tMCMGA1UdEQQcMBqCDCoubm9kZWpzLm9yZ4IKbm9kZWpzLm9yZzANBgkqhkiG9w0BAQsFAAOCAQEASDpkkfX7Feoa0/C/m+DkAZRzg+mEacWfk2CPQEl5y+XfUHxIaN9boBvU9vYTonmy4+cIolVEgoIAWE4ckHZe8UDG1xpDbLOTxMFDzZlw5Q1KhGklibNxlNRKV+esSH+vQMBGbOYXBnJrEv0TwrR+autRyBRq+PArgmAUFyzwp/dUne+t90j8ys/qcjy0nJ2u2/9uh5smb/9rQT3VbVCipJQetpionZXDGNWSwJvMK+kI6/1bESkdRFPIFqmd5u6R9HVk1GHz3vy8oAq6HuqiyVmV3ylIeuui1PN/MJ7wNmpKHmJx6deP0rullujAEXAf0QRFq39TiLld//8aIx/ZSg==​​​​​'
 
@@ -122,6 +123,7 @@ HmJx6deP0rullujAEXAf0QRFq39TiLld//8aIx/ZSg==
       expect(err.message).to.be.equal('The website did not provide a certificate')
       done()
     })
+	
   })
 
   it('should pass the certificate to the callback if successful', function(done) {
@@ -160,4 +162,19 @@ HmJx6deP0rullujAEXAf0QRFq39TiLld//8aIx/ZSg==
       done()
     })
   })
+  
+
+})
+
+describe('getSSLCertificate.get() live tests', function() { 
+  var timeoutUrl = 'singnet.com.sg'
+  
+  // Timeout test
+  it('should reject with an error if the timeout is exceeded', function(done) {
+    getSSLCertificate.get(timeoutUrl, {timeout: 500}).catch(function(err) {
+      expect(err).to.be.equal('Timeout triggered after ' + 500 + ' ms')
+      done()
+    })
+  })
+  
 })


### PR DESCRIPTION
Due to issues found with some domains resulting in 30 second execution time.
It is now possible to add an opts object to the funciton

e.g.

ssl.get('singnet.com.sg', {timeout: 5000})