### PR TITLE
PEM Encoded Key Format Fix

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@ function pemEncode(str, n) {
     }
   }
 
-  var returnString = `-----BEGIN CERTIFICATE-----\n${ret.join('')}\n-----END CERTIFICATE-----`
+  var returnString = `-----BEGIN CERTIFICATE-----\n${ret.join('')}-----END CERTIFICATE-----`
 
   return returnString
 }


### PR DESCRIPTION
This removes an extra new line in the PEM encoded key format. Previously, the key looked like this:

```
-----BEGIN CERTIFICATE-----
...

-----END CERTIFICATE-----
```

but it should look like this:

```
-----BEGIN CERTIFICATE-----
...
-----END CERTIFICATE-----
```
