### PR TITLE
Optional Port and Protocol parameters

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,12 +25,14 @@ function pemEncode(str, n) {
   return returnString;
 }
 
-function getOptions(url) {
+function getOptions(url, port, protocol) {
   return {
     hostname: url,
     agent: false,
     rejectUnauthorized: false,
-    ciphers: 'ALL'
+    ciphers: 'ALL',
+    port,
+    protocol
   };
 }
 
@@ -55,10 +57,10 @@ function handleRequest(options, resolve, reject) {
   });
 }
 
-function get(url, timeout) {
+function get(url, timeout, port = 443, protocol = 'https:') {
   validateUrl(url);
 
-  var options = getOptions(url);
+  var options = getOptions(url, port, protocol);
 
   return new Promise(function(resolve, reject) {
     var req = handleRequest(options, resolve, reject);


### PR DESCRIPTION
This PR introduces the option to pass a protocol other than https: and a port other than 443 to the get function. This will allow users of the package to use local authorization servers during development mode that aren't running on port 443 or https. 