### PR TITLE
Fix to timeout not being respected

### DIFF
--- a/index.js
+++ b/index.js
@@ -65,14 +65,15 @@ function get(url, timeout, port, protocol, detailed) {
 
   var options = getOptions(url, port, protocol);
   
-  if (timeout)
+  if (timeout) {
     options['timeout'] = timeout;
+  }
 
   return new Promise(function(resolve, reject) {
     var req = handleRequest(options, detailed, resolve, reject);
 
     if (timeout) {
-      req.on('timeout', ()=> {
+      req.on('timeout', () => {
         reject({ message: 'Request timed out.' });
         req.abort();
       });

--- a/index.js
+++ b/index.js
@@ -64,12 +64,15 @@ function get(url, timeout, port, protocol, detailed) {
   protocol = protocol || 'https:';
 
   var options = getOptions(url, port, protocol);
+  
+  if (timeout)
+    options['timeout'] = timeout;
 
   return new Promise(function(resolve, reject) {
     var req = handleRequest(options, detailed, resolve, reject);
 
     if (timeout) {
-      req.setTimeout(timeout, function() {
+      req.on('timeout', ()=> {
         reject({ message: 'Request timed out.' });
         req.abort();
       });

--- a/test/index.js
+++ b/test/index.js
@@ -145,4 +145,16 @@ describe('Live getSSLCertificate.get()', function() {
         done();
       });
   });
+  
+  it('should timeout at expected time', function(done) {
+    const startTime = new Date();
+    getSSLCertificate
+      .get('59.96.120.246', 1400) // Not sure which unreachable IP to put in here
+      .catch(function(error) {
+        const endTime = new Date();
+        expect(error.message).to.be.equal('Request timed out.');
+        expect(endTime - startTime).to.be.below(1500); // 100 ms of tolerance
+        done();
+      });
+  });
 });


### PR DESCRIPTION
When setting an unreachable IP from your network as the host address, the script fails to return a timeout error at the expected time. I tried to minimally change your script to fix this by using the ClientRequest 'timeout' option when calling 'https.get()'. Also I'm using 'ClientRequest.on('timeout)...' to listen the timeout event. The added test can be used to verify that the error occurs currently. This solution can be improved however, specially the IP used for the test, as someone could have a server running there.